### PR TITLE
Cannot reassign imported binding `Config`

### DIFF
--- a/app/initializers/em-idx-list.js
+++ b/app/initializers/em-idx-list.js
@@ -5,7 +5,7 @@ export default {
   name: 'ember-idx-list',
   initialize: function() {
     if (!Em.Config) {
-        Em.Config = Config = Config.create()
+        Em.Config = Config.create()
     }
   }
 };


### PR DESCRIPTION
Hi there,
Thanks for the ember components buddy, really helpful.
While using ember-idx-list with  ember-cli 0.2.0-beta.1 (ember-cli/ember-cli@ab2d770), I got the following error: 

```
Cannot reassign imported binding `Config`
```

This is similar to indexiatech/ember-idx-modal#15 reported by @kimf and the fix is similar to @pzuraq's fix here: indexiatech/ember-idx-modal#9 by removing the reassignment.
