### PR TITLE
Changes to comply Ember 2 and change deprecating items

### DIFF
--- a/addon/as-item.js
+++ b/addon/as-item.js
@@ -25,7 +25,7 @@ export default Em.Mixin.create({
    */
   index: (function() {
     return this.get('list.items').indexOf(this);
-  }).property('list.items.@each'),
+  }).property('list.items.[]'),
 
   /**
    * Register this item in the {{#crossLink "List"}}List{{/crossLink}} component instance.

--- a/addon/list.js
+++ b/addon/list.js
@@ -132,5 +132,5 @@ export default Em.Component.extend(WithConfigMixin, {
         return i.sendAction('on-model-change', i, _this.get('models'));
       };
     })(this));
-  }).observes('models', 'models.@each', 'models.length')
+  }).observes('models', 'models.[]', 'models.length')
 });

--- a/app/initializers/em-idx-list.js
+++ b/app/initializers/em-idx-list.js
@@ -5,7 +5,7 @@ export default {
   name: 'ember-idx-list',
   initialize: function() {
     if (!Em.Config) {
-        Em.Config = Config = Config.create()
+        Em.Config = Em.IdxConfig = Config.create()
     }
   }
 };


### PR DESCRIPTION
Observing on `@each` is deprecated.
In this PR they are substituted by `[]` 
